### PR TITLE
FEAT-23. Create first HTML page for journaling entry

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
 
 from app.api.v1.api import api_router
 from app.core.config import settings
@@ -25,3 +26,4 @@ app = FastAPI(
 )
 
 app.include_router(api_router, prefix="/api/v1")
+app.mount("/static", StaticFiles(directory="app/static"), name="static")

--- a/app/schemas/journal.py
+++ b/app/schemas/journal.py
@@ -9,9 +9,8 @@ class JournalCreate(BaseModel):
         description="Main textual content",
         example="Today I felt surprisingly calm and reflective",
     )
-    mood: str | None = Field(
+    mood: constr(strip_whitespace=True, max_length=50) | None = Field(
         default=None,
-        max_length=50,
         description="Mood tag",
     )
 

--- a/app/static/journal.html
+++ b/app/static/journal.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Create Journal Entry</title>
+</head>
+<body>
+    <h1>New Journal Entry</h1>
+    <form id="journal-form">
+        <label for="content">Content:</label><br>
+        <textarea id="content" name="content" rows="8" cols="40" required></textarea><br><br>
+
+        <label for="mood">Mood:</label><br>
+        <input id="mood" type="text" name="mood" maxlength="50"><br><br>
+
+        <button type="submit">Submit</button>
+    </form>
+
+    <div id="response" style="margin-top: 1em;"></div>
+
+    <script>
+        document.getElementById('journal-form').addEventListener('submit', async (e) => {
+            e.preventDefault();
+
+            const content = e.target.content.value.trim();
+            const mood = e.target.mood.value.trim();
+
+            const payload = { content };
+            if (mood) payload.mood = mood;
+
+            const response = await fetch('/api/v1/journal', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+
+            const result = document.getElementById('response');
+            if (response.ok) {
+                const data = await response.json();
+                result.style.color = 'green';
+                result.textContent = 'Entry created! ID: ' + data.id;
+                e.target.reset();
+            } else {
+                const errorText = await response.text();
+                result.style.color = 'red';
+                result.textContent = 'Error ' + response.status + ': ' + errorText;
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
### Summary

Adds a minimal HTML interface for submitting journal entries via the existing `/api/v1/journal` endpoint. Ensures proper validation of the mood field, enforcing a maximum length constraint in the backend schema

### Changes

- Added static HTML form (journal.html) for journal entry creation
- Mounted /static/ directory in FastAPI via app.mount(...)
- Replaced `str` with `constr(..., max_length=50`) for _mood_ in **JournalCreate** schema to activate SSV
