### PR TITLE
FEAT-36. Implement landing page and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,30 @@
 ---
 
 ## Features (MVP)
-- Daily emotion & mood journaling with optional tags/triggers
-- Soft affirmations and prompts on entry or via Telegram bot (TBD)
-- View, edit, and delete past journal entries
-- Visualization of emotional trends using charts
-- Calm, minimal UI with FastAPI, Jinja2 & HTMX
-- Testable and maintainable codebase with CI-friendly structure
+- **Beautiful Landing Page** - Professional and aesthetic main page at `/`
+- **Daily emotion & mood journaling** with optional tags/triggers
+- **Enhanced UI/UX** - Modern, responsive design with smooth animations
+- **Mood Suggestions** - Quick mood selection with emojis
+- **View, edit, and delete past journal entries** (API endpoints)
+- **Visualization of emotional trends** using charts (planned)
+- **Calm, minimal UI** with FastAPI, Jinja2 & HTMX
+- **Testable and maintainable codebase** with CI-friendly structure
+
+---
+
+## Quick Start
+
+### **Option 1: Direct Access**
+1. Start the application: `pdm run dev`
+2. Open your browser at: [http://127.0.0.1:8000](http://127.0.0.1:8000)
+
+### **Option 2: Journal Interface**
+1. Navigate to: [http://127.0.0.1:8000/static/journal.html](http://127.0.0.1:8000/static/journal.html)
+2. Or click "Create Your First Entry" from the main page
+
+### **Option 3: API Documentation**
+- Swagger UI: [http://127.0.0.1:8000/api/docs](http://127.0.0.1:8000/api/docs)
+- ReDoc: [http://127.0.0.1:8000/api/redoc](http://127.0.0.1:8000/api/redoc)
 
 ---
 
@@ -43,22 +61,21 @@
 - [ ] Create `.env` file for environment variables:
   ```bash
   touch .env
+  echo "database_url=sqlite:///./test.db" >> .env
+  echo "debug=true" >> .env
   ```
 
 ---
 
-## DB Migrations
-- [ ] Populate `.env` with the correct connection string:
-  ```bash
-  echo "DATABASE_URL=postgresql://<USER>:<PASS>@<HOST>:5432/<DB_NAME>" >> .env
+## Running the App Locally
+Start the FastAPI server with:
 
-- [ ] Generate a new migration revision:
-  ```bash
-  pdm run alembic -c pyproject.toml revision --autogenerate -m "Initial migration"
+```bash
+pdm run dev
+```
 
-- [ ] Apply all pending migrations:
-  ```bash
-  pdm run alembic -c pyproject.toml upgrade head
+Then open your browser at:
+[http://127.0.0.1:8000](http://127.0.0.1:8000)
 
 ---
 
@@ -123,3 +140,5 @@ allure open allure-report
 - Advanced visualizations of emotion trends
 - User authentication (optional)
 - Deployment with Docker
+- Dark/Light theme toggle
+- Export functionality (PDF, JSON)

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from app.api.v1.api import api_router
@@ -27,3 +28,9 @@ app = FastAPI(
 
 app.include_router(api_router, prefix="/api/v1")
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
+
+
+@app.get("/")
+async def root():
+    """Serve the main page"""
+    return FileResponse("app/static/index.html")

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>LumaireJ🖤🤍 — Journaling</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;1,400&family=Crimson+Text:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --ivory-1: #f5f1e8;
+            --ivory-2: #ebe4d8;
+            --sage-1: #e0e8e0;
+            --sage-2: #c8d5c8;
+            --sage-3: #8ba68b;
+            --sage-4: #5a7a5a;
+            --text: #1a2a1a;
+            --muted: #4a5a4a;
+            --white: #ffffff;
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: 'Crimson Text', Georgia, serif;
+            background: linear-gradient(135deg, var(--ivory-1) 0%, var(--sage-1) 100%);
+            min-height: 100vh;
+            color: var(--text);
+        }
+
+        .container { max-width: 1100px; margin: 0 auto; padding: 2rem; }
+
+        .header { text-align: center; margin-bottom: 3rem; color: var(--text); }
+
+        .logo {
+            font-family: 'Playfair Display', serif;
+            font-size: 2.8rem;
+            font-weight: 400;
+            letter-spacing: 0.5px;
+        }
+
+        .tagline {
+            font-family: 'Crimson Text', serif;
+            font-style: italic;
+            font-size: 1.1rem;
+            margin-top: 0.75rem;
+            color: var(--muted);
+        }
+
+        .btn {
+            display: inline-block;
+            padding: 0.85rem 1.4rem;
+            border-radius: 999px;
+            text-decoration: none;
+            font-weight: 600;
+            font-family: 'Crimson Text', serif;
+            transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+        }
+        .btn:hover { transform: translateY(-1px); box-shadow: 0 8px 18px rgba(0,0,0,0.08); }
+        .btn-primary { background: linear-gradient(135deg, var(--sage-3), var(--sage-4)); color: var(--white); }
+        .btn-ghost { background: var(--white); color: var(--sage-4); border: 1px solid var(--sage-2); }
+
+        .main-content { background: rgba(255, 255, 255, 0.9); border-radius: 18px; padding: 2.2rem; box-shadow: 0 14px 36px rgba(0,0,0,0.06); backdrop-filter: blur(6px); }
+
+        .features { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1.4rem; margin: 2rem 0 2.4rem; }
+
+        .feature-card { background: linear-gradient(180deg, var(--ivory-2), var(--white)); padding: 1.6rem; border-radius: 14px; box-shadow: 0 8px 22px rgba(0,0,0,0.05); border: 1px solid var(--sage-2); transition: transform 0.2s ease, box-shadow 0.2s ease; }
+        .feature-card:hover { transform: translateY(-2px); box-shadow: 0 16px 30px rgba(0,0,0,0.08); }
+        .feature-title {
+            font-family: 'Playfair Display', serif;
+            font-size: 1.1rem;
+            font-weight: 600;
+            margin-bottom: 0.6rem;
+            color: var(--text);
+        }
+        .feature-description {
+            color: var(--muted);
+            line-height: 1.6;
+            font-size: 0.98rem;
+            font-style: italic;
+        }
+
+        .cta { text-align: center; background: linear-gradient(135deg, var(--ivory-2), var(--sage-2)); border: 1px solid var(--sage-2); border-radius: 14px; padding: 1.6rem; }
+        .cta h2 {
+            font-family: 'Playfair Display', serif;
+            font-size: 1.4rem;
+            font-weight: 500;
+            margin-bottom: 0.6rem;
+        }
+        .cta p { color: var(--muted); margin-bottom: 1.2rem; font-style: italic; }
+
+        .nav-links { text-align: center; margin-top: 1.8rem; }
+        .nav-links a { color: var(--sage-4); text-decoration: none; margin: 0 0.8rem; font-weight: 500; }
+        .nav-links a:hover { text-decoration: underline; }
+
+        @media (max-width: 768px) {
+            .container { padding: 1.25rem; }
+            .logo { font-size: 2.1rem; }
+            .main-content { padding: 1.6rem; }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header class="header">
+            <h1 class="logo">LumaireJ🖤🤍</h1>
+            <p class="tagline">Quiet space for reflection</p>
+        </header>
+
+        <main class="main-content">
+            <section class="features">
+                <article class="feature-card">
+                    <h3 class="feature-title">Write</h3>
+                    <p class="feature-description">Capture a moment as it is. No pressure, no metrics, just your words.</p>
+                </article>
+                <article class="feature-card">
+                    <h3 class="feature-title">Notice</h3>
+                    <p class="feature-description">Name what you feel and gently track patterns over time.</p>
+                </article>
+                <article class="feature-card">
+                    <h3 class="feature-title">Revisit</h3>
+                    <p class="feature-description">Return when you're ready. Your space stays quiet and yours.</p>
+                </article>
+            </section>
+
+            <div class="cta">
+                <h2>Begin softly</h2>
+                <p>A single line is enough today.</p>
+                <a href="/static/journal.html" class="btn btn-primary">Start writing</a>
+            </div>
+
+            <div class="nav-links">
+                <a href="/static/journal.html">Journal</a>
+                <a href="/api/docs">API Docs</a>
+                <a href="https://github.com/darliaro/lumairej" target="_blank" rel="noreferrer noopener">GitHub</a>
+            </div>
+        </main>
+    </div>
+</body>
+</html>

--- a/app/static/journal.html
+++ b/app/static/journal.html
@@ -2,25 +2,268 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Create Journal Entry</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Create Journal Entry - LumaireJ</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;1,400&family=Crimson+Text:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --ivory-1: #f5f1e8;
+            --ivory-2: #ebe4d8;
+            --sage-1: #e0e8e0;
+            --sage-2: #c8d5c8;
+            --sage-3: #8ba68b;
+            --sage-4: #5a7a5a;
+            --text: #1a2a1a;
+            --muted: #4a5a4a;
+            --white: #ffffff;
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: 'Crimson Text', Georgia, serif;
+            background: linear-gradient(135deg, var(--ivory-1) 0%, var(--sage-1) 100%);
+            min-height: 100vh;
+            color: var(--text);
+        }
+
+        .container { max-width: 900px; margin: 0 auto; padding: 2rem; }
+
+        .header { text-align: center; margin-bottom: 1.5rem; color: var(--text); }
+
+        .logo {
+            font-family: 'Playfair Display', serif;
+            font-size: 2.2rem;
+            font-weight: 400;
+            letter-spacing: 0.3px;
+        }
+
+        .subtitle {
+            font-size: 1rem;
+            opacity: 0.9;
+            font-weight: 400;
+            color: var(--muted);
+            margin-top: 0.4rem;
+        }
+
+        .main-content { background: rgba(255, 255, 255, 0.92); border-radius: 18px; padding: 2rem; box-shadow: 0 14px 36px rgba(0,0,0,0.06); backdrop-filter: blur(6px); }
+
+        .form-group { margin-bottom: 1.6rem; }
+
+        label {
+            display: block;
+            margin-bottom: 0.5rem;
+            font-weight: 600;
+            color: var(--text);
+            font-size: 1.05rem;
+        }
+
+        textarea, input[type="text"] {
+            width: 100%;
+            padding: 1rem;
+            border: 2px solid var(--sage-2);
+            border-radius: 12px;
+            font-size: 1rem;
+            font-family: inherit;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease;
+            background: var(--white);
+        }
+
+        textarea:focus, input[type="text"]:focus {
+            outline: none;
+            border-color: var(--sage-3);
+            box-shadow: 0 0 0 3px rgba(139, 166, 139, 0.18);
+        }
+
+        textarea { resize: vertical; min-height: 140px; }
+
+        .btn {
+            display: inline-block;
+            padding: 0.9rem 1.6rem;
+            background: linear-gradient(135deg, var(--sage-3), var(--sage-4));
+            color: var(--white);
+            text-decoration: none;
+            border: none;
+            border-radius: 999px;
+            font-weight: 700;
+            font-size: 1rem;
+            font-family: 'Crimson Text', serif;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+            box-shadow: 0 8px 18px rgba(0,0,0,0.08);
+        }
+
+        .btn:hover { transform: translateY(-1px); box-shadow: 0 12px 24px rgba(0,0,0,0.12); }
+        .btn:disabled { opacity: 0.6; cursor: not-allowed; transform: none; }
+
+        .response { margin-top: 1.4rem; padding: 1rem; border-radius: 12px; font-weight: 500; text-align: center; }
+        .response.success { background: #e7f6ec; color: #235c37; border: 1px solid #cfe9d8; }
+        .response.error { background: #fdecec; color: #7a2327; border: 1px solid #f7c7cb; }
+
+        .nav-links { text-align: center; margin-top: 1.6rem; }
+        .nav-links a { color: var(--sage-4); text-decoration: none; margin: 0 0.8rem; font-weight: 500; }
+        .nav-links a:hover { text-decoration: underline; }
+
+        .mood-suggestions {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 0.8rem;
+            margin-top: 0.8rem;
+        }
+
+        .mood-tag {
+            display: flex;
+            align-items: center;
+            gap: 0.6rem;
+            padding: 0.6rem 0.8rem;
+            background: var(--ivory-2);
+            border: 1px solid var(--sage-2);
+            border-radius: 12px;
+            cursor: pointer;
+            transition: transform 0.15s ease, background-color 0.15s ease, border-color 0.15s ease;
+            font-size: 0.9rem;
+            user-select: none;
+        }
+        .mood-tag:hover {
+            transform: translateY(-1px);
+            background: var(--white);
+            border-color: var(--sage-3);
+        }
+        .mood-emoji { font-size: 1.2rem; }
+        .mood-label {
+            font-family: 'Crimson Text', serif;
+            font-style: italic;
+            color: var(--muted);
+        }
+
+        @media (max-width: 768px) {
+            .container { padding: 1rem; }
+            .main-content { padding: 1.4rem; }
+            .logo { font-size: 1.7rem; }
+            .mood-suggestions { grid-template-columns: 1fr; }
+        }
+    </style>
 </head>
 <body>
-    <h1>New Journal Entry</h1>
-    <form id="journal-form">
-        <label for="content">Content:</label><br>
-        <textarea id="content" name="content" rows="8" cols="40" required></textarea><br><br>
+    <div class="container">
+        <header class="header">
+            <h1 class="logo">LumaireJ🖤🤍</h1>
+            <p class="subtitle">Write when you're ready</p>
+        </header>
 
-        <label for="mood">Mood:</label><br>
-        <input id="mood" type="text" name="mood" maxlength="50"><br><br>
+        <main class="main-content">
+            <form id="journal-form">
+                <div class="form-group">
+                    <label for="content">Your note</label>
+                    <textarea
+                        id="content"
+                        name="content"
+                        placeholder="Write freely…"
+                        required
+                    ></textarea>
+                </div>
 
-        <button type="submit">Submit</button>
-    </form>
+                <div class="form-group">
+                    <label for="mood">Mood (optional)</label>
+                    <input
+                        id="mood"
+                        type="text"
+                        name="mood"
+                        maxlength="50"
+                        placeholder="Pick a mood below or type your own"
+                    >
+                    <div class="mood-suggestions">
+                        <span class="mood-tag" onclick="setMood('😍', 'In Love')">
+                            <span class="mood-emoji">😍</span>
+                            <span class="mood-label">In Love</span>
+                        </span>
+                        <span class="mood-tag" onclick="setMood('🤩', 'Excited')">
+                            <span class="mood-emoji">🤩</span>
+                            <span class="mood-label">Excited</span>
+                        </span>
+                        <span class="mood-tag" onclick="setMood('😊', 'Happy')">
+                            <span class="mood-emoji">😊</span>
+                            <span class="mood-label">Happy</span>
+                        </span>
+                        <span class="mood-tag" onclick="setMood('🤗', 'Grateful')">
+                            <span class="mood-emoji">🤗</span>
+                            <span class="mood-label">Grateful</span>
+                        </span>
+                        <span class="mood-tag" onclick="setMood('😌', 'Calm')">
+                            <span class="mood-emoji">😌</span>
+                            <span class="mood-label">Calm</span>
+                        </span>
+                        <span class="mood-tag" onclick="setMood('🙂', 'Content')">
+                            <span class="mood-emoji">🙂</span>
+                            <span class="mood-label">Content</span>
+                        </span>
+                        <span class="mood-tag" onclick="setMood('😐', 'Neutral')">
+                            <span class="mood-emoji">😐</span>
+                            <span class="mood-label">Neutral</span>
+                        </span>
+                        <span class="mood-tag" onclick="setMood('🤔', 'Thoughtful')">
+                            <span class="mood-emoji">🤔</span>
+                            <span class="mood-label">Thoughtful</span>
+                        </span>
+                        <span class="mood-tag" onclick="setMood('😕', 'Confused')">
+                            <span class="mood-emoji">😕</span>
+                            <span class="mood-label">Confused</span>
+                        </span>
+                        <span class="mood-tag" onclick="setMood('😴', 'Tired')">
+                            <span class="mood-emoji">😴</span>
+                            <span class="mood-label">Tired</span>
+                        </span>
+                        <span class="mood-tag" onclick="setMood('😔', 'Sad')">
+                            <span class="mood-emoji">😔</span>
+                            <span class="mood-label">Sad</span>
+                        </span>
+                        <span class="mood-tag" onclick="setMood('😰', 'Anxious')">
+                            <span class="mood-emoji">😰</span>
+                            <span class="mood-label">Anxious</span>
+                        </span>
+                        <span class="mood-tag" onclick="setMood('😤', 'Frustrated')">
+                            <span class="mood-emoji">😤</span>
+                            <span class="mood-label">Frustrated</span>
+                        </span>
+                        <span class="mood-tag" onclick="setMood('😠', 'Angry')">
+                            <span class="mood-emoji">😠</span>
+                            <span class="mood-label">Angry</span>
+                        </span>
+                        <span class="mood-tag" onclick="setMood('😭', 'Devastated')">
+                            <span class="mood-emoji">😭</span>
+                            <span class="mood-label">Devastated</span>
+                        </span>
+                    </div>
+                </div>
 
-    <div id="response" style="margin-top: 1em;"></div>
+                <button type="submit" class="btn" id="submit-btn">Save entry</button>
+            </form>
+
+            <div id="response" class="response" style="display: none;"></div>
+
+            <div class="nav-links">
+                <a href="/">← Home</a>
+                <a href="/api/docs">API Docs</a>
+            </div>
+        </main>
+    </div>
 
     <script>
+        function setMood(emoji, label) {
+            document.getElementById('mood').value = emoji + ' ' + label;
+        }
+
         document.getElementById('journal-form').addEventListener('submit', async (e) => {
             e.preventDefault();
+
+            const submitBtn = document.getElementById('submit-btn');
+            const responseDiv = document.getElementById('response');
+
+            submitBtn.disabled = true;
+            submitBtn.textContent = 'Saving...';
+            responseDiv.style.display = 'none';
 
             const content = e.target.content.value.trim();
             const mood = e.target.mood.value.trim();
@@ -28,22 +271,42 @@
             const payload = { content };
             if (mood) payload.mood = mood;
 
-            const response = await fetch('/api/v1/journal', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(payload)
-            });
+            try {
+                const response = await fetch('/api/v1/journal', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload)
+                });
 
-            const result = document.getElementById('response');
-            if (response.ok) {
-                const data = await response.json();
-                result.style.color = 'green';
-                result.textContent = 'Entry created! ID: ' + data.id;
-                e.target.reset();
-            } else {
-                const errorText = await response.text();
-                result.style.color = 'red';
-                result.textContent = 'Error ' + response.status + ': ' + errorText;
+                responseDiv.style.display = 'block';
+
+                if (response.ok) {
+                    const data = await response.json();
+                    responseDiv.className = 'response success';
+                    responseDiv.innerHTML = `
+                        <strong>Saved</strong><br>
+                        id: ${data.id}<br>
+                        at: ${new Date(data.created_at).toLocaleString()}
+                    `;
+                    e.target.reset();
+                } else {
+                    const errorText = await response.text();
+                    responseDiv.className = 'response error';
+                    responseDiv.innerHTML = `
+                        <strong>Error ${response.status}</strong><br>
+                        ${errorText}
+                    `;
+                }
+            } catch (error) {
+                responseDiv.style.display = 'block';
+                responseDiv.className = 'response error';
+                responseDiv.innerHTML = `
+                    <strong>Network error</strong><br>
+                    Please try again.
+                `;
+            } finally {
+                submitBtn.disabled = false;
+                submitBtn.textContent = 'Save entry';
             }
         });
     </script>

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:b2bcd82a41d9d70e89691138bef818c581af9c75551ba6fb540e16b1ae5eb112"
+content_hash = "sha256:925b829f754d8c51daae6e7387b432e10d3b672a2837e7ecb3beda1b7d561c39"
 
 [[metadata.targets]]
 requires_python = "==3.13.*"


### PR DESCRIPTION
### Summary

Introduce a public landing page and refine the journaling UI to present a calm, professional aesthetic. Serve the landing page at “/” and streamline navigation (CTA-focused, API Docs in footer)

### Changes

- Add app/static/index.html landing page with herb/ivory color palette and elegant typography
- Serve landing page at `/ `via `app/main.py`
- Keep single CTA “Start writing” in the landing page section; “API Docs” link in footer
- Restyle app/static/journal.html to match palette/typography; improve form UX; add 15 mood tags (round-face emoji + labels) ordered positive → negative
