### PR TITLE
[REFACTOR #52] Extract validation constants to eliminate magic numbers

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -1,0 +1,4 @@
+# Field validation limits - single source of truth
+CONTENT_MIN_LENGTH = 1
+CONTENT_MAX_LENGTH = 5000
+MOOD_MAX_LENGTH = 50

--- a/app/models/journal.py
+++ b/app/models/journal.py
@@ -2,14 +2,16 @@ from datetime import UTC, datetime
 
 from sqlmodel import Field, SQLModel
 
+from app.constants import CONTENT_MAX_LENGTH, CONTENT_MIN_LENGTH
+
 
 class JournalEntry(SQLModel, table=True):
     __tablename__ = "journal_entries"
 
     id: int | None = Field(primary_key=True, description="Unique identifier for the journal entry")
     content: str = Field(
-        min_length=1,
-        max_length=5000,
+        min_length=CONTENT_MIN_LENGTH,
+        max_length=CONTENT_MAX_LENGTH,
         description="Main textual content written by the user",
     )
     created_at: datetime = Field(

--- a/app/schemas/journal.py
+++ b/app/schemas/journal.py
@@ -2,14 +2,16 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field, PositiveInt, constr
 
+from app.constants import CONTENT_MAX_LENGTH, CONTENT_MIN_LENGTH, MOOD_MAX_LENGTH
+
 
 class JournalCreate(BaseModel):
-    content: constr(strip_whitespace=True, min_length=1, max_length=5000) = Field(
+    content: constr(strip_whitespace=True, min_length=CONTENT_MIN_LENGTH, max_length=CONTENT_MAX_LENGTH) = Field(
         ...,
         description="Main textual content",
         example="Today I felt surprisingly calm and reflective",
     )
-    mood: constr(strip_whitespace=True, max_length=50) | None = Field(
+    mood: constr(strip_whitespace=True, max_length=MOOD_MAX_LENGTH) | None = Field(
         default=None,
         description="Mood tag",
     )


### PR DESCRIPTION
## Summary

- Create `app/constants.py` as single source of truth for field validation limits
- Update `models/journal.py` and `schemas/journal.py` to use constants
- Eliminates DRY violation and reduces maintenance burden

## Changes

| File | Change |
|------|--------|
| `app/constants.py` | **New** - Define CONTENT_MIN_LENGTH, CONTENT_MAX_LENGTH, MOOD_MAX_LENGTH |
| `app/models/journal.py` | Use constants for content field validation |
| `app/schemas/journal.py` | Use constants for content and mood field validation |

## Constants Defined

```python
CONTENT_MIN_LENGTH = 1
CONTENT_MAX_LENGTH = 5000
MOOD_MAX_LENGTH = 50
```

## Test plan

- [ ] Verify linting passes
- [ ] Verify existing tests still pass
- [ ] Confirm validation behavior unchanged

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)