### PR TITLE
[REFACTOR #57] Quick wins: minor code quality improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,8 +16,8 @@
 # Migrations or scripts
 !alembic/**
 
-# Tests
-!tests/**
+# Tests - excluded from production image
+# !tests/**
 
 # CI/CD and helper scripts
 !ci/**

--- a/app/main.py
+++ b/app/main.py
@@ -43,3 +43,9 @@ app.mount("/static", StaticFiles(directory="app/static"), name="static")
 async def root():
     """Serve the main page"""
     return FileResponse("app/static/index.html")
+
+
+@app.get("/health")
+async def health():
+    """Health check endpoint for container orchestration"""
+    return {"status": "healthy"}

--- a/app/models/journal.py
+++ b/app/models/journal.py
@@ -18,4 +18,4 @@ class JournalEntry(SQLModel, table=True):
         default_factory=lambda: datetime.now(UTC),
         description="Timestamp of entry creation in UTC",
     )
-    mood: str | None = Field(description="Optional mood tag")
+    mood: str | None = Field(default=None, description="Optional mood tag")

--- a/app/schemas/journal.py
+++ b/app/schemas/journal.py
@@ -6,12 +6,12 @@ from app.constants import CONTENT_MAX_LENGTH, CONTENT_MIN_LENGTH, MOOD_MAX_LENGT
 
 
 class JournalCreate(BaseModel):
-    content: constr(strip_whitespace=True, min_length=CONTENT_MIN_LENGTH, max_length=CONTENT_MAX_LENGTH) = Field(
+    content: constr(min_length=CONTENT_MIN_LENGTH, max_length=CONTENT_MAX_LENGTH) = Field(
         ...,
         description="Main textual content",
-        example="Today I felt surprisingly calm and reflective",
+        json_schema_extra={"examples": ["Today I felt surprisingly calm and reflective"]},
     )
-    mood: constr(strip_whitespace=True, max_length=MOOD_MAX_LENGTH) | None = Field(
+    mood: constr(max_length=MOOD_MAX_LENGTH) | None = Field(
         default=None,
         description="Mood tag",
     )


### PR DESCRIPTION
## Summary

- Exclude tests from production Docker image (`.dockerignore`)
- Add `/health` endpoint for container orchestration
- Add explicit `default=None` to mood field in model
- Remove redundant `strip_whitespace` from `constr` (already handled by `model_config`)
- Fix deprecated `example` param → `json_schema_extra`

## Test plan

- [x] `pdm run lint` passes
- [x] `pdm run test` passes
- [ ] Manual test: `GET /health` returns `{"status": "healthy"}`

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)