### PR TITLE
[ARCH #59] Restrict CORS methods and headers for security

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -31,8 +31,8 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.allowed_origins,
     allow_credentials=False,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
+    allow_headers=["Content-Type", "Accept"],
 )
 
 app.include_router(api_router, prefix="/api/v1")


### PR DESCRIPTION
## Summary
- Restricted `allow_methods` from `["*"]` to `["GET", "POST", "PATCH", "DELETE", "OPTIONS"]`
- Restricted `allow_headers` from `["*"]` to `["Content-Type", "Accept"]`

## Test Plan
- [x] Lint passes (`pdm run lint`)
- [x] Tests pass (`pdm run test`)
- [ ] Manual testing: verify frontend still works with restricted CORS

Closes #59