### PR TITLE
[ARCH #62] Add updated_at timestamp to JournalEntry model

### DIFF
--- a/alembic/versions/62a1b2c3d4e5_add_updated_at_to_journal_entries.py
+++ b/alembic/versions/62a1b2c3d4e5_add_updated_at_to_journal_entries.py
@@ -1,0 +1,32 @@
+"""Add updated_at to journal_entries
+
+Revision ID: 62a1b2c3d4e5
+Revises: 419a7670b421
+Create Date: 2026-01-19
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "62a1b2c3d4e5"
+down_revision: str | Sequence[str] | None = "419a7670b421"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add updated_at column to journal_entries."""
+    op.add_column(
+        "journal_entries",
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Remove updated_at column from journal_entries."""
+    op.drop_column("journal_entries", "updated_at")

--- a/app/crud/journal.py
+++ b/app/crud/journal.py
@@ -1,12 +1,28 @@
+from datetime import UTC, datetime
+
 from sqlmodel import Session
 
 from app.models.journal import JournalEntry
-from app.schemas import JournalCreate
+from app.schemas.journal import JournalCreate, JournalUpdate
 
 
 def create_journal_entry(session: Session, data: JournalCreate) -> JournalEntry:
     """Create and persist a new journal entry."""
     entry = JournalEntry(**data.model_dump())
+    session.add(entry)
+    session.commit()
+    session.refresh(entry)
+    return entry
+
+
+def update_journal_entry(
+    session: Session, entry: JournalEntry, data: JournalUpdate
+) -> JournalEntry:
+    """Update an existing journal entry and set updated_at timestamp."""
+    update_data = data.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(entry, field, value)
+    entry.updated_at = datetime.now(UTC)
     session.add(entry)
     session.commit()
     session.refresh(entry)

--- a/app/models/journal.py
+++ b/app/models/journal.py
@@ -18,4 +18,8 @@ class JournalEntry(SQLModel, table=True):
         default_factory=lambda: datetime.now(UTC),
         description="Timestamp of entry creation in UTC",
     )
+    updated_at: datetime | None = Field(
+        default=None,
+        description="Timestamp of last modification in UTC",
+    )
     mood: str | None = Field(default=None, description="Optional mood tag")

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,1 +1,1 @@
-from .journal import JournalCreate, JournalRead  # noqa: F401
+from .journal import JournalCreate, JournalRead, JournalUpdate  # noqa: F401

--- a/app/schemas/journal.py
+++ b/app/schemas/journal.py
@@ -19,6 +19,19 @@ class JournalCreate(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True)
 
 
+class JournalUpdate(BaseModel):
+    content: constr(min_length=CONTENT_MIN_LENGTH, max_length=CONTENT_MAX_LENGTH) | None = Field(
+        default=None,
+        description="Main textual content",
+    )
+    mood: constr(max_length=MOOD_MAX_LENGTH) | None = Field(
+        default=None,
+        description="Mood tag",
+    )
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+
 class JournalRead(BaseModel):
     id: PositiveInt = Field(
         ...,
@@ -31,6 +44,10 @@ class JournalRead(BaseModel):
     created_at: datetime = Field(
         ...,
         description="Timestamp of entry creation in UTC",
+    )
+    updated_at: datetime | None = Field(
+        default=None,
+        description="Timestamp of last modification in UTC",
     )
     mood: str | None = Field(
         default=None,


### PR DESCRIPTION
## Summary
- Add `updated_at` field to `JournalEntry` model (nullable, default None)
- Add `updated_at` field to `JournalRead` schema
- Add `JournalUpdate` schema for PATCH operations
- Add `update_journal_entry()` CRUD function that sets `updated_at` to current UTC time
- Add database migration for new column

## Test Plan
- [x] Lint passes (`pdm run lint`)
- [x] Tests pass (`pdm run test`)
- [ ] Run migration on dev database
- [ ] Verify new entries have `updated_at: null`

Closes #62