### PR TITLE
[ARCH #63] Make allowed_origins configurable via environment variable

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,2 +1,4 @@
 DATABASE_URL=
 DEBUG=True
+# Comma-separated list of allowed CORS origins (optional, has defaults)
+# ALLOWED_ORIGINS=http://localhost,http://localhost:8000,https://example.com

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,16 +1,29 @@
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+DEFAULT_ALLOWED_ORIGINS = [
+    "http://localhost",
+    "http://localhost:8000",
+    "http://127.0.0.1",
+    "http://127.0.0.1:8000",
+    "https://darliaro.github.io",
+]
 
 
 class Settings(BaseSettings):
     database_url: str
     debug: bool = False
-    allowed_origins: list[str] = [
-        "http://localhost",
-        "http://localhost:8000",
-        "http://127.0.0.1",
-        "http://127.0.0.1:8000",
-        "https://darliaro.github.io",
-    ]
+    allowed_origins: list[str] = DEFAULT_ALLOWED_ORIGINS
+
+    @field_validator("allowed_origins", mode="before")
+    @classmethod
+    def parse_allowed_origins(cls, v: str | list[str] | None) -> list[str]:
+        """Parse comma-separated string into list of origins."""
+        if v is None:
+            return DEFAULT_ALLOWED_ORIGINS
+        if isinstance(v, str):
+            return [origin.strip() for origin in v.split(",") if origin.strip()]
+        return v
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- Add `field_validator` to parse comma-separated `ALLOWED_ORIGINS` env var
- Fall back to default origins list if env var not set
- Update `.env.template` with commented example

## Usage
```bash
# In .env file
ALLOWED_ORIGINS=http://localhost,http://localhost:8000,https://example.com
```

## Test Plan
- [x] Lint passes (`pdm run lint`)
- [x] Tests pass (`pdm run test`)
- [ ] Test with custom `ALLOWED_ORIGINS` env var
- [ ] Test without env var (uses defaults)

Closes #63