### PR TITLE
[ARCH #61] Add global exception handlers

### DIFF
--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -1,0 +1,55 @@
+"""Global exception handlers for consistent API error responses."""
+
+import logging
+
+from fastapi import FastAPI, Request, status
+from fastapi.responses import JSONResponse
+from pydantic import ValidationError
+from sqlalchemy.exc import IntegrityError, OperationalError
+
+logger = logging.getLogger(__name__)
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    """Register all exception handlers with the FastAPI app."""
+
+    @app.exception_handler(ValidationError)
+    async def validation_error_handler(
+        request: Request, exc: ValidationError
+    ) -> JSONResponse:
+        """Handle Pydantic validation errors with structured details."""
+        return JSONResponse(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            content={
+                "detail": [
+                    {
+                        "loc": list(error["loc"]),
+                        "msg": error["msg"],
+                        "type": error["type"],
+                    }
+                    for error in exc.errors()
+                ]
+            },
+        )
+
+    @app.exception_handler(IntegrityError)
+    async def integrity_error_handler(
+        request: Request, exc: IntegrityError
+    ) -> JSONResponse:
+        """Handle database integrity errors (e.g., unique constraint violations)."""
+        logger.error("Database integrity error: %s", exc)
+        return JSONResponse(
+            status_code=status.HTTP_409_CONFLICT,
+            content={"detail": "Resource conflict or duplicate entry"},
+        )
+
+    @app.exception_handler(OperationalError)
+    async def operational_error_handler(
+        request: Request, exc: OperationalError
+    ) -> JSONResponse:
+        """Handle database operational errors (e.g., connection issues)."""
+        logger.error("Database operational error: %s", exc)
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            content={"detail": "Service temporarily unavailable"},
+        )

--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ from fastapi.staticfiles import StaticFiles
 from app.api.v1.api import api_router
 from app.core.config import settings
 from app.core.database import init_db
+from app.core.exceptions import register_exception_handlers
 
 
 @asynccontextmanager
@@ -34,6 +35,8 @@ app.add_middleware(
     allow_methods=["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
     allow_headers=["Content-Type", "Accept"],
 )
+
+register_exception_handlers(app)
 
 app.include_router(api_router, prefix="/api/v1")
 app.mount("/static", StaticFiles(directory="app/static"), name="static")


### PR DESCRIPTION
## Summary
- Add `ValidationError` handler → 422 with structured error details
- Add `IntegrityError` handler → 409 Conflict
- Add `OperationalError` handler → 503 Service Unavailable
- Register all handlers in `app/main.py`

## Exception Handling
| Exception | Status | Response |
|-----------|--------|----------|
| ValidationError | 422 | Structured `{loc, msg, type}` |
| IntegrityError | 409 | "Resource conflict or duplicate entry" |
| OperationalError | 503 | "Service temporarily unavailable" |

## Test Plan
- [x] Lint passes (`pdm run lint`)
- [x] Tests pass (`pdm run test`)
- [ ] Test validation errors return proper 422 format
- [ ] Test database errors don't leak internal details

Closes #61