### PR TITLE
[ARCH #78] Harden CLAUDE.md and command files from prompt audit

### DIFF
--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -11,7 +11,8 @@ Run linting and tests before pushing.
    ```bash
    pdm run lint
    ```
-   If errors found, offer to run `pdm run format` to auto-fix.
+   - If errors found, run `pdm run format` to auto-fix.
+   - Re-run `pdm run lint` to verify. If issues persist after formatting, list them and fix manually.
 
 2. **Run tests**:
    ```bash
@@ -19,8 +20,10 @@ Run linting and tests before pushing.
    ```
 
 3. **Report results**:
-   - If all pass: "Ready to push"
-   - If failures: List specific issues and offer to fix them
+   - If all pass: "Ready to push."
+   - If lint failures remain after auto-fix: list the specific issues and offer to fix them.
+   - If test failures: list the failing tests with error output and offer to investigate.
+   - Do NOT report "ready to push" if any check is failing.
 
 4. **Show git status** for awareness:
    ```bash

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -12,8 +12,12 @@ Create a commit following project conventions.
    git status
    git diff --staged
    ```
+   - If there are no staged changes AND no unstaged changes, inform the user: "Nothing to commit." and stop.
+   - If there are unstaged changes but nothing staged, show the changed files and ask what to stage.
 
-2. **Extract issue number** from current branch name (e.g., `feat/42-description` → `42`)
+2. **Extract issue number** from current branch name (e.g., `feat/42-description` → `42`):
+   - If the branch is `main` or has no issue number, ask the user: "Which issue number is this commit for?"
+   - Do NOT create a commit without a valid issue number.
 
 3. **Determine commit type** from branch prefix:
    | Branch Prefix | Commit Type |
@@ -22,6 +26,8 @@ Create a commit following project conventions.
    | `fix/` | `FIX` |
    | `refactor/` | `REFACTOR` |
    | `arch/` | `ARCH` |
+
+   If the branch prefix doesn't match any known type, ask the user which commit type to use. Do NOT guess.
 
 4. **Stage relevant changes** if not already staged:
    ```bash
@@ -39,6 +45,7 @@ Create a commit following project conventions.
    ```bash
    git log -1
    ```
+   If the commit failed (e.g., pre-commit hook rejection), report the specific error and offer to fix it. Do NOT retry with `--no-verify`.
 
 ## Commit Description
 $ARGUMENTS

--- a/.claude/commands/complete-issue.md
+++ b/.claude/commands/complete-issue.md
@@ -3,7 +3,13 @@
 Clean up local environment after PR is merged.
 
 ## Arguments
-- `$ARGUMENTS` - Issue number
+- `$ARGUMENTS` - Issue number (REQUIRED)
+
+## Validation
+If `$ARGUMENTS` is empty or not a valid issue number:
+1. Check the current branch name for an issue number (e.g., `feat/42-desc` → `42`)
+2. If no issue number can be inferred, ask the user: "Which issue number should I complete?"
+3. Do NOT proceed without a valid issue number.
 
 ## Instructions
 
@@ -12,6 +18,10 @@ Clean up local environment after PR is merged.
    gh issue view <issue-number>
    gh pr list --state merged --search "<issue-number>"
    ```
+   - If the PR is NOT merged, **stop** and inform the user:
+     "PR for issue #X is not merged yet. Complete the review/merge process first."
+   - Do NOT proceed with cleanup if the PR is still open.
+
    Note: GitHub automation automatically:
    - Moves PR to 🚀 Deployed when merged
    - Closes the linked issue
@@ -21,6 +31,7 @@ Clean up local environment after PR is merged.
    ```bash
    git checkout main
    ```
+   If checkout fails due to uncommitted changes, inform the user and stop.
 
 3. **Pull latest changes**:
    ```bash
@@ -31,6 +42,8 @@ Clean up local environment after PR is merged.
    ```bash
    git branch -d <branch-name>
    ```
+   - If the branch doesn't exist locally, skip this step (it may have already been deleted).
+   - If `-d` fails because the branch is not fully merged, warn the user and ask before using `-D`.
 
 5. **Verify remote branch is deleted** (should be auto-deleted by merge):
    ```bash

--- a/.claude/commands/fix.md
+++ b/.claude/commands/fix.md
@@ -7,26 +7,37 @@ Handle requested changes after PR review.
 
 ## Instructions
 
-1. **Fetch latest review feedback**:
+1. **Determine PR number**:
+   - If `$ARGUMENTS` contains a PR number, use it.
+   - Otherwise, infer from the current branch:
+     ```bash
+     gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number'
+     ```
+   - If no PR can be found, ask the user for the PR number.
+
+2. **Fetch latest review feedback**:
    ```bash
    gh pr view <pr-number>
    gh pr checks <pr-number>
    ```
 
-2. **Display requested changes** from the review to user clearly.
+3. **Display requested changes** from the review to user clearly.
 
-3. **Guide through fix workflow**:
-   - Instruct user: "Make the necessary code changes to address the feedback"
-   - Wait for user confirmation that changes are made
+4. **Implement the fixes**:
+   - Analyze the review feedback and identify required code changes
+   - Make the code changes directly to address each piece of feedback
+   - If a feedback item is ambiguous or requires a design decision, ask the user for clarification before proceeding
 
-4. **Run quality checks**:
+5. **Run quality checks**:
    ```bash
    pdm run lint
    pdm run test
    ```
-   If errors found, offer to run `pdm run format` to auto-fix linting issues.
+   - If lint fails, run `pdm run format` and re-check. If issues persist, fix them manually.
+   - If tests fail, analyze and fix. If failures are unrelated to the review changes, inform the user.
+   - Do NOT push if quality checks fail.
 
-5. **Create fix commit**:
+6. **Create fix commit**:
    - Extract issue number from branch
    - Determine commit type from branch prefix
    - Create commit with descriptive message:
@@ -37,18 +48,18 @@ Handle requested changes after PR review.
      Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
      ```
 
-6. **Push changes**:
+7. **Push changes**:
    ```bash
    git push
    ```
    Note: This automatically updates the PR. GitHub automation keeps PR in 🔄 In Progress.
 
-7. **Notify reviewer** (optional):
+8. **Notify reviewer** (optional):
    ```bash
    gh pr comment <pr-number> --body "Changes addressed and pushed. Ready for re-review."
    ```
 
-8. **Report** to user: "Changes pushed successfully. PR updated and ready for re-review."
+9. **Report** to user: "Changes pushed successfully. PR updated and ready for re-review."
 
 ## PR or Context
 $ARGUMENTS

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -12,7 +12,9 @@ Create a pull request following project conventions.
    pdm run lint
    pdm run test
    ```
-   Fix any issues before proceeding.
+   - If lint fails, run `pdm run format` and re-check. If issues persist after formatting, fix them manually.
+   - If tests fail, analyze and fix the failures before proceeding.
+   - If failures cannot be resolved, **stop** and report the specific errors to the user. Do NOT create a PR with failing checks.
 
 2. **Get branch and issue info**:
    ```bash
@@ -20,8 +22,11 @@ Create a pull request following project conventions.
    git log main..HEAD --oneline
    git diff main...HEAD --stat
    ```
+   - If on `main`, **stop**: "You are on main. Create a feature branch first using `/start-work`."
+   - If there are no commits ahead of main, **stop**: "No changes to create a PR for."
 
-3. **Extract issue number** from branch name (e.g., `feat/42-description` → `42`)
+3. **Extract issue number** from branch name (e.g., `feat/42-description` → `42`):
+   - If no issue number can be extracted, ask the user which issue this PR addresses.
 
 4. **Determine PR type** from branch prefix:
    | Branch Prefix | PR Type |
@@ -30,6 +35,8 @@ Create a pull request following project conventions.
    | `fix/` | `FIX` |
    | `refactor/` | `REFACTOR` |
    | `arch/` | `ARCH` |
+
+   If the branch prefix doesn't match, ask the user which type to use.
 
 5. **Push branch** if not already pushed:
    ```bash

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -36,11 +36,13 @@ Review a pull request following project conventions.
 5. **Make decision** based on review:
 
    **If APPROVED:**
-   - Submit approval:
+   - **STOP: Do NOT merge without human confirmation.** Present findings to the user and ask:
+     "PR #X passes all review checks. Approve and merge?"
+   - Only after the user explicitly confirms, submit approval:
      ```bash
      gh pr review <pr-number> --approve --body "LGTM - changes look good"
      ```
-   - Auto-merge the PR:
+   - Then merge the PR:
      ```bash
      gh pr merge <pr-number> --squash --delete-branch
      ```

--- a/.claude/commands/start-work.md
+++ b/.claude/commands/start-work.md
@@ -3,16 +3,30 @@
 Create a branch and begin work on a GitHub issue.
 
 ## Arguments
-- `$ARGUMENTS` - Issue number (e.g., "42" or "#42")
+- `$ARGUMENTS` - Issue number (REQUIRED, e.g., "42" or "#42")
+
+## Validation
+If `$ARGUMENTS` is empty or not a valid issue number:
+- Ask the user: "Which issue number should I start work on?"
+- Do NOT proceed without a valid issue number.
 
 ## Instructions
 
-1. **Fetch issue details**:
+1. **Pre-flight check** — verify clean working tree:
+   ```bash
+   git status --porcelain
+   ```
+   - If there are uncommitted changes, **stop** and ask the user:
+     "You have uncommitted changes. Stash them, commit them, or discard before switching branches?"
+   - Do NOT proceed until the working tree is clean.
+
+2. **Fetch issue details**:
    ```bash
    gh issue view <issue-number>
    ```
+   If the issue doesn't exist or is already closed, inform the user and stop.
 
-2. **Determine branch prefix** from issue title:
+3. **Determine branch prefix** from issue title:
    | Issue Type | Branch Prefix |
    |------------|---------------|
    | `[FEAT]` | `feat/` |
@@ -20,23 +34,28 @@ Create a branch and begin work on a GitHub issue.
    | `[REFACTOR]` | `refactor/` |
    | `[ARCH]` | `arch/` |
 
-3. **Ensure main is up to date**:
+   If the issue title doesn't match any type, ask the user which prefix to use. Do NOT guess.
+
+4. **Ensure main is up to date**:
    ```bash
    git checkout main && git pull origin main
    ```
+   - If `git pull` fails due to merge conflicts, **stop** and inform the user:
+     "Merge conflicts on main. Please resolve manually before starting new work."
+   - Do NOT force-pull or discard changes.
 
-4. **Create and checkout branch**:
+5. **Create and checkout branch**:
    ```bash
    git checkout -b <prefix>/<issue-number>-<short-description>
    ```
    Example: `feat/42-user-authentication`
 
-5. **Move issue to In Progress** on the project board:
+6. **Move issue to In Progress** on the project board:
    ```bash
    # Get issue node ID
    ISSUE_NODE_ID=$(gh issue view <issue-number> --json id --jq '.id')
 
-   # Get project item ID (add to project if not already there)
+   # Add issue to project (returns item ID even if already added)
    ITEM_ID=$(gh api graphql -f query='
      mutation($project: ID!, $content: ID!) {
        addProjectV2ItemById(input: {projectId: $project, contentId: $content}) {
@@ -44,16 +63,37 @@ Create a branch and begin work on a GitHub issue.
        }
      }' -f project="PVT_kwHODR8J4s4A9wbx" -f content="$ISSUE_NODE_ID" --jq '.data.addProjectV2ItemById.item.id')
 
+   # Dynamically look up the "Status" field and "In Progress" option
+   PROJECT_DATA=$(gh api graphql -f query='
+     query($project: ID!) {
+       node(id: $project) {
+         ... on ProjectV2 {
+           field(name: "Status") {
+             ... on ProjectV2SingleSelectField {
+               id
+               options { id name }
+             }
+           }
+         }
+       }
+     }' -f project="PVT_kwHODR8J4s4A9wbx")
+
+   FIELD_ID=$(echo "$PROJECT_DATA" | jq -r '.data.node.field.id')
+   OPTION_ID=$(echo "$PROJECT_DATA" | jq -r '.data.node.field.options[] | select(.name == "In Progress") | .id')
+
    # Move to In Progress
    gh api graphql -f query='
      mutation($project: ID!, $item: ID!, $field: ID!, $value: String!) {
        updateProjectV2ItemFieldValue(input: {projectId: $project, itemId: $item, fieldId: $field, value: {singleSelectOptionId: $value}}) {
          projectV2Item { id }
        }
-     }' -f project="PVT_kwHODR8J4s4A9wbx" -f item="$ITEM_ID" -f field="PVTSSF_lAHODR8J4s4A9wbxzgxXTgM" -f value="47fc9ee4"
+     }' -f project="PVT_kwHODR8J4s4A9wbx" -f item="$ITEM_ID" -f field="$FIELD_ID" -f value="$OPTION_ID"
    ```
+   Note: The project ID `PVT_kwHODR8J4s4A9wbx` is stable. Field and option IDs are looked up dynamically so the command survives project board reconfiguration.
 
-6. **Confirm** the branch is ready, issue moved to 🔄 In Progress, and summarize the issue.
+   If the GraphQL calls fail (e.g., permission error, project not found), warn the user but continue — the branch is still usable. Project board status can be updated manually.
+
+7. **Confirm** the branch is ready, issue moved to 🔄 In Progress, and summarize the issue.
 
 ## Issue Number
 $ARGUMENTS

--- a/claude.md
+++ b/claude.md
@@ -1,33 +1,20 @@
 # LumaireJ - Claude Code Guide
 
-## Project Overview
+<role>
+You are a backend-focused software engineer working on LumaireJ, a journaling app for emotional self-awareness and reflection. You follow the project's issue-first workflow strictly and never bypass quality gates.
+</role>
 
-**LumaireJ** is a journaling app for emotional self-awareness and reflection. MVP stage with growth planned.
+<constraints>
+## Non-Negotiable Rules
 
-### Tech Stack
-- **Backend**: FastAPI + SQLModel + PostgreSQL (SQLite for dev)
-- **Frontend**: Vanilla HTML/CSS/JS + HTMX
-- **Package Manager**: PDM
-- **Linting**: ruff
-- **Testing**: pytest
-- **CI/CD**: GitHub Actions → GitHub Pages (frontend)
-
-### Architecture
-
-```
-app/
-├── core/           # config.py, database.py - infrastructure
-├── dependencies/   # session.py - FastAPI DI
-├── models/         # SQLModel table definitions
-├── schemas/        # Pydantic request/response validation
-├── crud/           # Database operations (one file per resource)
-├── api/v1/         # Versioned API routers
-├── static/         # Frontend HTML/CSS/JS
-├── constants.py    # Validation limits (single source of truth)
-└── main.py         # App entry, middleware, lifespan
-```
-
-This modular structure is intentional (see `docs/adr/001-keep-modular-architecture.md`). Do not flatten.
+- **NEVER** write code without a linked GitHub issue. No exceptions, even for "quick fixes."
+- **NEVER** push directly to `main`. All changes go through feature branches.
+- **NEVER** merge a PR without explicit human approval from the repository owner. Do not self-approve and merge PRs you authored in the current session.
+- **NEVER** modify `.github/workflows/`, `CLAUDE.md`, or `.claude/commands/` without explicit user request.
+- **NEVER** skip `pdm run lint` and `pdm run test` before commits, even if the user requests it. Explain why and refuse.
+- **NEVER** hardcode secrets, API keys, or credentials in source files.
+- **DO NOT** flatten the modular architecture (see `docs/adr/001-keep-modular-architecture.md`).
+</constraints>
 
 ---
 
@@ -73,6 +60,15 @@ Concept → /new-issue → 📋 Backlog (GitHub auto)
 | `/fix` | Fix post-review | Handles fix loop: fetch feedback → check → commit → push |
 | `/complete <#>` | Post-merge cleanup | Updates local repo, deletes branch |
 
+### Command Argument Handling
+
+When a command requires arguments (e.g., issue number) and none are provided:
+1. Attempt to infer from context (e.g., extract issue number from current branch name)
+2. If inference fails, **ask the user** — do NOT guess or proceed without required data
+
+When a branch prefix doesn't match any known type (`feat/`, `fix/`, `refactor/`, `arch/`):
+- Ask the user which commit type to use. Do NOT guess.
+
 ### Branch Naming
 
 | Issue Type | Prefix | Example |
@@ -117,6 +113,38 @@ Before approving a PR, verify:
 - Linting passes (`pdm run lint`)
 - Tests pass (`pdm run test`)
 - Changes match issue requirements
+- **Human reviewer has explicitly approved before merging**
+
+---
+
+## Project Overview
+
+**LumaireJ** is a journaling app for emotional self-awareness and reflection. MVP stage with growth planned.
+
+### Tech Stack
+- **Backend**: FastAPI + SQLModel + PostgreSQL (SQLite for dev)
+- **Frontend**: Vanilla HTML/CSS/JS + HTMX
+- **Package Manager**: PDM
+- **Linting**: ruff
+- **Testing**: pytest
+- **CI/CD**: GitHub Actions → GitHub Pages (frontend)
+
+### Architecture
+
+```
+app/
+├── core/           # config.py, database.py - infrastructure
+├── dependencies/   # session.py - FastAPI DI
+├── models/         # SQLModel table definitions
+├── schemas/        # Pydantic request/response validation
+├── crud/           # Database operations (one file per resource)
+├── api/v1/         # Versioned API routers
+├── static/         # Frontend HTML/CSS/JS
+├── constants.py    # Validation limits (single source of truth)
+└── main.py         # App entry, middleware, lifespan
+```
+
+This modular structure is intentional (see `docs/adr/001-keep-modular-architecture.md`). Do not flatten.
 
 ---
 
@@ -276,10 +304,11 @@ def test_session():
 
 ### Current Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| POST | `/api/v1/journal` | Create journal entry |
-| GET | `/health` | Health check |
+Refer to the auto-generated docs for the authoritative endpoint list:
+- **Swagger UI**: run `pdm run dev`, then visit `http://localhost:8000/api/docs`
+- **ReDoc**: `http://localhost:8000/api/redoc`
+
+Do NOT maintain a static endpoint table here — the live docs are the single source of truth.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `<role>` and `<constraints>` XML blocks to the top of `CLAUDE.md` with 7 explicit NEVER rules (no direct push to main, no self-merge, no skipping checks, etc.)
- Restructure `CLAUDE.md` to place Workflow Rules above Project Overview, fixing lost-in-the-middle attention bias
- Add human-gate to `/review-pr` — Claude must present findings and get explicit user confirmation before approving/merging
- Replace hardcoded GraphQL field/option IDs in `/start-work` with dynamic lookups (project ID kept stable)
- Add `Command Argument Handling` section with inference-then-ask fallback rules
- Add argument validation, error handling, and conflict resolution paths to all 7 command files
- Replace static API endpoints table with pointer to live Swagger/ReDoc docs
- Fix `/fix` command role ambiguity — Claude now implements changes directly instead of coaching the user

## Test Plan
- [x] `pdm run lint` passes
- [x] `pdm run test` passes (2/2)
- [ ] Manual verification: invoke `/commit` on `main` branch → should refuse
- [ ] Manual verification: invoke `/review-pr` → should ask for human confirmation before merge

Closes #78