### PR TITLE
[ARCH #86] Fix all CI/CD pipeline issues across three workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   lint-and-unit-tests:  # Job 1: Checkout, install, lint & run unit tests
     name: Lint & Unit Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     permissions:
       contents: read
 
@@ -32,7 +32,7 @@ jobs:
         uses: actions/cache@v4
         with:
           key: pdm-${{ runner.os }}-${{ hashFiles('pdm.lock') }}
-          restore-keys: pdm-
+          restore-keys: pdm-${{ runner.os }}-
           path: |
             ~/.cache/pdm
             .venv
@@ -77,6 +77,8 @@ jobs:
             });
 
       - name: Dispatch to test repo
+        id: dispatch
+        continue-on-error: true
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ env.PAT }}
@@ -88,3 +90,18 @@ jobs:
               "sha": "${{ github.sha }}",
               "pr_number": "${{ github.event.pull_request.number }}"
             }
+
+      - name: Mark external tests as failed if dispatch failed
+        if: steps.dispatch.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.sha,
+              state: 'failure',
+              context: 'API & E2E Tests',
+              description: 'Failed to dispatch external tests — check PAT_FOR_TESTS_REPO secret and LumaireJ-tests repo'
+            });

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,10 +3,8 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
-  workflow_run:
-    workflows: ["PR Lint & Unit Tests"]
-    types: [completed]
-    branches: [main]
+    paths:
+      - 'app/static/**'
   workflow_dispatch:
 
 permissions:
@@ -22,10 +20,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
+    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -33,8 +28,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'workflow_run' && 'main' || github.event.after || github.sha }}
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -27,8 +27,13 @@ jobs:
     if: github.event_name == 'issues' && github.event.action == 'opened'
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    timeout-minutes: 5
     steps:
+      - name: Validate PROJECT_TOKEN
+        run: |
+          if [ -z "${{ secrets.PROJECT_TOKEN }}" ]; then
+            echo "::error::PROJECT_TOKEN secret is not set or empty"
+            exit 1
+          fi
       - name: Add issue to project
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
@@ -53,6 +58,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Validate PROJECT_TOKEN
+        run: |
+          if [ -z "${{ secrets.PROJECT_TOKEN }}" ]; then
+            echo "::error::PROJECT_TOKEN secret is not set or empty"
+            exit 1
+          fi
       - name: Get project item ID
         id: get-item
         env:
@@ -88,6 +99,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Validate PROJECT_TOKEN
+        run: |
+          if [ -z "${{ secrets.PROJECT_TOKEN }}" ]; then
+            echo "::error::PROJECT_TOKEN secret is not set or empty"
+            exit 1
+          fi
       - name: Add PR to project and set AI Review
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
@@ -112,6 +129,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Validate PROJECT_TOKEN
+        run: |
+          if [ -z "${{ secrets.PROJECT_TOKEN }}" ]; then
+            echo "::error::PROJECT_TOKEN secret is not set or empty"
+            exit 1
+          fi
       - name: Get project item ID
         id: get-item
         env:
@@ -147,6 +170,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Validate PROJECT_TOKEN
+        run: |
+          if [ -z "${{ secrets.PROJECT_TOKEN }}" ]; then
+            echo "::error::PROJECT_TOKEN secret is not set or empty"
+            exit 1
+          fi
       - name: Get project item ID
         id: get-item
         env:


### PR DESCRIPTION
## Summary

Fixes 8 issues identified in a full CI/CD pipeline audit across all three workflow files.

### project-automation.yml
- Remove duplicate `timeout-minutes: 5` key (YAML parse failure on every push — root cause of persistent failures)
- Add `PROJECT_TOKEN` validation step to all 5 jobs — makes auth failures explicit instead of silent

### ci.yml
- Reduce `timeout-minutes: 30` → `10` (tests run in ~50s)
- Scope cache `restore-keys` to OS (`pdm-${{ runner.os }}-`) to prevent cross-OS cache poisoning
- Add fallback failure status if external test dispatch fails — prevents forever-pending status blocking future merges

### deploy-pages.yml
- Remove dead `workflow_run` trigger (CI runs on PR branches, never on `main`, so condition never matched)
- Add `paths: ['app/static/**']` filter to push trigger — prevents rebuilding Pages on backend-only changes
- Simplify checkout step (no more complex ternary ref expression)

## Test Plan
- [x] All 36 tests pass locally
- [x] Lint + format check passes
- [ ] Verify `project-automation.yml` no longer fails on next issue/PR event
- [ ] Verify Pages deploy only triggers on `app/static/` changes

Closes #85
Closes #86